### PR TITLE
Update Swift concurrency roadmap for strict-gate rollout

### DIFF
--- a/SWIFT6_CONCURRENCY_IMPROVEMENT.md
+++ b/SWIFT6_CONCURRENCY_IMPROVEMENT.md
@@ -4,7 +4,7 @@
 
 This document tracks concurrency modernization in **JJYWave**, including what is already complete and what should be implemented next after PR #24.
 
-## Current State (Post-PR #23)
+## Current State (Post-PR #24)
 
 The codebase remains primarily queue-based (`DispatchQueue`, `DispatchSourceTimer`) for real-time audio safety, with selective Swift concurrency usage (`Task { @MainActor ... }`) for UI-facing callback hops.
 

--- a/SWIFT6_CONCURRENCY_IMPROVEMENT.md
+++ b/SWIFT6_CONCURRENCY_IMPROVEMENT.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This document tracks concurrency modernization in **JJYWave**, including what is already complete and what should be implemented next after PR #23.
+This document tracks concurrency modernization in **JJYWave**, including what is already complete and what should be implemented next after PR #24.
 
 ## Current State (Post-PR #23)
 
@@ -87,9 +87,37 @@ The codebase remains primarily queue-based (`DispatchQueue`, `DispatchSourceTime
 ## Next Step Strategy (Post-Phase D)
 
 1. Continue hybrid model: queue isolation for real-time/timing-critical code, actors for configuration and UI-adjacent state boundaries.
-2. Add one more bounded actor slice (candidate: frequency/UI coordination state facade) behind existing protocols.
-3. Keep validating with strict diagnostics build plus focused and full test suites per phase.
-4. Reassess broader migration only after multiple bounded slices show net maintainability gain with zero timing regressions.
+2. Enable strict-concurrency checks as a default quality gate (warnings-as-errors in CI for touched modules first, then repository-wide).
+3. Resolve remaining isolation mismatch hotspots before Swift 6 language mode migration (notably `PresentationControllerProtocol` / `ViewController` conformance boundary).
+4. Keep validating with strict diagnostics build plus focused and full test suites per phase.
+5. Reassess broader actor migration only after strict checks remain stable with zero timing regressions.
+
+## Recommended Immediate Next Tasks (Phase E)
+
+### E1. Strict Concurrency by default (Swift 5 mode)
+
+1. Keep `SWIFT_VERSION = 5.0`, but run with strict concurrency diagnostics enabled by default in CI.
+2. Treat new strict-concurrency warnings as merge blockers for changed files.
+3. Preserve current runtime behavior; avoid broad async refactors in this step.
+
+### E2. Remove temporary suppression at UI boundary
+
+1. Replace `@preconcurrency` conformance workaround in `App/ViewController.swift` with an explicit actor-safe protocol boundary.
+2. Preferred target shape: main-actor-isolated presentation protocol and explicit main-actor hop strategy at coordinator call boundaries.
+3. Update affected tests to match the final isolation boundary.
+
+### E3. Swift 6 language mode pilot (module-by-module)
+
+1. After E1/E2 are green, pilot `SWIFT_VERSION = 6.0` on the smallest safe target surface first.
+2. Promote to repository-wide Swift 6 language mode only after pilot completes without timing regressions or flaky tests.
+
+## Should We Enable Strict Concurrency Now?
+
+Short answer: **Yes, as diagnostics gate; not yet as full Swift 6 language-mode switch across the whole repository.**
+
+1. Immediate go: strict-concurrency diagnostics should be continuously enforced.
+2. Controlled follow-up: remove current workaround hotspots (especially UI protocol isolation boundary).
+3. Then switch: move to Swift 6 language mode once diagnostics are clean and stable under repeated test runs.
 
 ## Suggested Branch/PR Order
 
@@ -102,7 +130,9 @@ Completed:
 
 Suggested next:
 
-5. `swift6-concurrency-phase-e-state-facade`
+5. `swift6-concurrency-phase-e-strict-gate`
+6. `swift6-concurrency-phase-f-ui-boundary-alignment`
+7. `swift6-concurrency-phase-g-swift6-pilot`
 
 ## Definition of Done (Updated)
 
@@ -110,3 +140,5 @@ Suggested next:
 2. UI boundary isolation is explicit and consistent.
 3. Strict concurrency diagnostics are improved with no functional regressions.
 4. Actor migration decisions are based on measured prototype results, not assumptions.
+5. Strict-concurrency diagnostics are continuously enforced in CI.
+6. Swift 6 language mode migration is completed only after hotspot cleanup and stable repeated test runs.


### PR DESCRIPTION
## Summary
- update `SWIFT6_CONCURRENCY_IMPROVEMENT.md` to reflect post-PR #24 state and define concrete next steps
- set the recommended sequencing to enable strict-concurrency diagnostics as a default gate first, then migrate to Swift 6 language mode in controlled stages
- document immediate Phase E tasks, including UI isolation-boundary cleanup and a module-by-module Swift 6 pilot path

## Why
- current implementation status and next actions were out of date after PR #24
- we need a clear, low-risk migration path that improves concurrency safety without regressing timing-sensitive behavior