### PR TITLE
Add strict-concurrency diagnostics gate script

### DIFF
--- a/App/ViewController.swift
+++ b/App/ViewController.swift
@@ -151,15 +151,8 @@ final class ViewController: NSViewController {
     }
     
     // MARK: - Lifecycle
-    deinit {
-        let timer = timeUpdateTimer
-        let monitor = spaceKeyMonitor
-        Task { @MainActor in
-            timer?.invalidate()
-            if let monitor = monitor {
-                NSEvent.removeMonitor(monitor)
-            }
-        }
+    @MainActor deinit {
+        cleanupResources()
     }
 
     override func viewWillDisappear() {

--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ JJYWave/
 - 同一キュー再入時は追加 `async` を避け、即時実行で順序性を保つ。
 - オーディオのタイミングクリティカル経路では、挙動検証前に安易な並列化を行わない。
 
+### Strict Concurrency Check
+- Swift 6 移行準備として、以下の strict-concurrency 診断ゲートを実行できます。
+
+```bash
+./scripts/strict_concurrency_check.sh
+```
+
+- このスクリプトは `SWIFT_STRICT_CONCURRENCY=complete` かつ warnings-as-errors で `xcodebuild` を実行します。
+
 ## 貢献
 - 実験プロジェクトとして Issue / Pull Request を歓迎します。大きな変更は事前に議論してください。
 

--- a/scripts/strict_concurrency_check.sh
+++ b/scripts/strict_concurrency_check.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+echo "Running strict-concurrency diagnostics check..."
+
+xcodebuild \
+  -project "JJYWave.xcodeproj" \
+  -scheme "JJYWave" \
+  -destination "platform=macOS" \
+  -configuration Debug \
+  SWIFT_STRICT_CONCURRENCY=complete \
+  GCC_TREAT_WARNINGS_AS_ERRORS=YES \
+  SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
+  build
+
+echo "Strict-concurrency diagnostics check passed."


### PR DESCRIPTION
## Summary
- add `scripts/strict_concurrency_check.sh` to run `xcodebuild` with `SWIFT_STRICT_CONCURRENCY=complete` and warnings-as-errors
- document the strict-concurrency gate command in `README.md`
- adjust `ViewController` teardown to `@MainActor deinit` with `cleanupResources()` so the strict-concurrency gate passes on current code

## Validation
- ran `./scripts/strict_concurrency_check.sh`
- result: strict-concurrency build succeeded