### PR TITLE
Add CI strict-concurrency diagnostics workflow

### DIFF
--- a/.github/workflows/strict-concurrency-check.yml
+++ b/.github/workflows/strict-concurrency-check.yml
@@ -10,12 +10,17 @@ on:
 
 jobs:
   strict-concurrency:
-    runs-on: macos-14
+    runs-on: macos-15
     timeout-minutes: 30
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
 
       - name: Run strict-concurrency diagnostics gate
         run: ./scripts/strict_concurrency_check.sh

--- a/.github/workflows/strict-concurrency-check.yml
+++ b/.github/workflows/strict-concurrency-check.yml
@@ -1,0 +1,21 @@
+name: Strict Concurrency Check
+
+on:
+  pull_request:
+    branches:
+      - Gen2
+  push:
+    branches:
+      - Gen2
+
+jobs:
+  strict-concurrency:
+    runs-on: macos-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run strict-concurrency diagnostics gate
+        run: ./scripts/strict_concurrency_check.sh

--- a/.github/workflows/strict-concurrency-check.yml
+++ b/.github/workflows/strict-concurrency-check.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   strict-concurrency:
-    runs-on: macos-latest
+    runs-on: macos-14
     timeout-minutes: 30
 
     steps:

--- a/scripts/strict_concurrency_check.sh
+++ b/scripts/strict_concurrency_check.sh
@@ -16,6 +16,8 @@ xcodebuild \
   SWIFT_STRICT_CONCURRENCY=complete \
   GCC_TREAT_WARNINGS_AS_ERRORS=YES \
   SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
+  CODE_SIGNING_ALLOWED=NO \
+  CODE_SIGNING_REQUIRED=NO \
   build
 
 echo "Strict-concurrency diagnostics check passed."


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run the strict-concurrency diagnostics gate on `Gen2` pushes and pull requests
- reuse the existing repository script (`./scripts/strict_concurrency_check.sh`) so local and CI checks stay aligned

## Validation
- ran `./scripts/strict_concurrency_check.sh` locally on this branch
- result: build succeeded with `SWIFT_STRICT_CONCURRENCY=complete` and warnings-as-errors