### PR TITLE
Align presentation boundary with MainActor isolation

### DIFF
--- a/App/ViewController.swift
+++ b/App/ViewController.swift
@@ -186,7 +186,7 @@ final class ViewController: NSViewController {
 
 // MARK: - PresentationControllerProtocol
 @MainActor
-extension ViewController: @preconcurrency PresentationControllerProtocol {
+extension ViewController: PresentationControllerProtocol {
     func updateButtonTitle(_ title: String) {
         startStopButton?.title = title
     }

--- a/JJYKit/Services/AudioGeneratorCoordinator.swift
+++ b/JJYKit/Services/AudioGeneratorCoordinator.swift
@@ -3,6 +3,7 @@ import Cocoa
 
 // MARK: - PresentationControllerProtocol
 /// Protocol for presentation layer to reduce coupling with business logic
+@MainActor
 protocol PresentationControllerProtocol: AnyObject {
     func updateButtonTitle(_ title: String)
     func updateStatusMessage(_ message: String)
@@ -56,14 +57,8 @@ final class AudioGeneratorCoordinator: AudioGeneratorCoordinatorProtocol {
         self.presentationController = controller
     }
 
-    private func performPresentationUpdate(_ update: @escaping @Sendable (PresentationControllerProtocol) -> Void) {
-        if Thread.isMainThread {
-            guard let presentationController = self.presentationController else { return }
-            update(presentationController)
-            return
-        }
-
-        DispatchQueue.main.sync { [weak self] in
+    private func performPresentationUpdate(_ update: @escaping @MainActor @Sendable (PresentationControllerProtocol) -> Void) {
+        Task { @MainActor [weak self] in
             guard let self = self else { return }
             guard let presentationController = self.presentationController else { return }
             update(presentationController)

--- a/Tests/FrequencyPersistenceTests.swift
+++ b/Tests/FrequencyPersistenceTests.swift
@@ -117,9 +117,14 @@ class FrequencyPersistenceTests: XCTestCase {
             uiStateManager: mockUIStateManager
         )
         coordinator.setPresentationController(mockPresentation)
+        let revertExpectation = expectation(description: "revert selection callback")
+        mockPresentation.onRevertSelection = { [weak mockPresentation] in
+            revertExpectation.fulfill()
+            mockPresentation?.onRevertSelection = nil
+        }
 
         coordinator.handleFrequencyChange(to: 3, currentIndex: 1)
-        await Task.yield()
+        await fulfillment(of: [revertExpectation], timeout: 1.0)
 
         let revertSelectionWasCalled = mockPresentation.revertSelectionWasCalled
         XCTAssertTrue(revertSelectionWasCalled,

--- a/Tests/FrequencyPersistenceTests.swift
+++ b/Tests/FrequencyPersistenceTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 // MARK: - FrequencyPersistenceTests
 /// Tests for UserDefaults-based persistence of the frequency segment selection.
+@MainActor
 class FrequencyPersistenceTests: XCTestCase {
 
     private let suiteName = "JJYWave.FrequencyPersistenceTests"
@@ -118,6 +119,7 @@ class FrequencyPersistenceTests: XCTestCase {
         coordinator.setPresentationController(mockPresentation)
 
         coordinator.handleFrequencyChange(to: 3, currentIndex: 1)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.01))
 
         let revertSelectionWasCalled = mockPresentation.revertSelectionWasCalled
         XCTAssertTrue(revertSelectionWasCalled,

--- a/Tests/FrequencyPersistenceTests.swift
+++ b/Tests/FrequencyPersistenceTests.swift
@@ -103,7 +103,7 @@ class FrequencyPersistenceTests: XCTestCase {
 
     /// Verifies that a blocked frequency change triggers a revert,
     /// which is the precondition for NOT saving.
-    func testBlockedFrequencyChangeTriggersRevert() {
+    func testBlockedFrequencyChangeTriggersRevert() async {
         let audioGenerator = JJYAudioGenerator()
         let mockFrequencyManager = MockFrequencyManager()
         let mockUIStateManager = MockUIStateManager()
@@ -119,7 +119,7 @@ class FrequencyPersistenceTests: XCTestCase {
         coordinator.setPresentationController(mockPresentation)
 
         coordinator.handleFrequencyChange(to: 3, currentIndex: 1)
-        RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+        await Task.yield()
 
         let revertSelectionWasCalled = mockPresentation.revertSelectionWasCalled
         XCTAssertTrue(revertSelectionWasCalled,

--- a/Tests/ModularArchitectureIntegrationTests.swift
+++ b/Tests/ModularArchitectureIntegrationTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import JJYWave
 
+@MainActor
 class ModularArchitectureIntegrationTests: XCTestCase {
     var audioGenerator: JJYAudioGenerator!
     var coordinator: AudioGeneratorCoordinator!
@@ -56,6 +57,7 @@ class ModularArchitectureIntegrationTests: XCTestCase {
         
         // Try to change to JJY60 while generating (should be blocked)
         coordinator.handleFrequencyChange(to: 4, currentIndex: 0)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.01))
         
         // Verify change was blocked
         let revertSelectionWasCalled = mockPresentationController.revertSelectionWasCalled
@@ -70,6 +72,7 @@ class ModularArchitectureIntegrationTests: XCTestCase {
     func testUIStateUpdatesCorrectly() {
         // Refresh UI state
         coordinator.refreshUIState()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.01))
         
         // Verify UI updates were called
         let updateFrequencyDisplayWasCalled = mockPresentationController.updateFrequencyDisplayWasCalled
@@ -152,12 +155,13 @@ class ModularArchitectureIntegrationTests: XCTestCase {
     func testConcurrentOperations() {
         let expectation = XCTestExpectation(description: "Concurrent operations should complete")
         let group = DispatchGroup()
+        let coordinator = self.coordinator!
         
         // Test concurrent frequency changes
         for i in 0..<10 {
             group.enter()
             DispatchQueue.global().async {
-                self.coordinator.handleFrequencyChange(to: i % 3, currentIndex: 0)
+                coordinator.handleFrequencyChange(to: i % 3, currentIndex: 0)
                 group.leave()
             }
         }
@@ -166,7 +170,7 @@ class ModularArchitectureIntegrationTests: XCTestCase {
         for _ in 0..<10 {
             group.enter()
             DispatchQueue.global().async {
-                self.coordinator.refreshUIState()
+                coordinator.refreshUIState()
                 group.leave()
             }
         }

--- a/Tests/ModularArchitectureIntegrationTests.swift
+++ b/Tests/ModularArchitectureIntegrationTests.swift
@@ -48,7 +48,7 @@ class ModularArchitectureIntegrationTests: XCTestCase {
         XCTAssertEqual(audioGenerator.band, .jjy40, "Should switch to JJY40")
     }
     
-    func testFrequencyChangeBlockedWhileGenerating() {
+    func testFrequencyChangeBlockedWhileGenerating() async {
         // Start generation
         coordinator.handleStartStopAction()
         
@@ -57,7 +57,7 @@ class ModularArchitectureIntegrationTests: XCTestCase {
         
         // Try to change to JJY60 while generating (should be blocked)
         coordinator.handleFrequencyChange(to: 4, currentIndex: 0)
-        RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+        await Task.yield()
         
         // Verify change was blocked
         let revertSelectionWasCalled = mockPresentationController.revertSelectionWasCalled
@@ -69,10 +69,10 @@ class ModularArchitectureIntegrationTests: XCTestCase {
         XCTAssertTrue(audioGenerator.isTestModeEnabled, "Should remain in test mode")
     }
     
-    func testUIStateUpdatesCorrectly() {
+    func testUIStateUpdatesCorrectly() async {
         // Refresh UI state
         coordinator.refreshUIState()
-        RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+        await Task.yield()
         
         // Verify UI updates were called
         let updateFrequencyDisplayWasCalled = mockPresentationController.updateFrequencyDisplayWasCalled

--- a/Tests/ModularArchitectureIntegrationTests.swift
+++ b/Tests/ModularArchitectureIntegrationTests.swift
@@ -54,10 +54,21 @@ class ModularArchitectureIntegrationTests: XCTestCase {
         
         // Verify generation started
         XCTAssertTrue(audioGenerator.isActive, "Should be generating")
+
+        let revertExpectation = expectation(description: "revert selection callback")
+        let statusExpectation = expectation(description: "status callback")
+        mockPresentationController.onRevertSelection = { [weak mockPresentationController] in
+            revertExpectation.fulfill()
+            mockPresentationController?.onRevertSelection = nil
+        }
+        mockPresentationController.onUpdateStatus = { [weak mockPresentationController] in
+            statusExpectation.fulfill()
+            mockPresentationController?.onUpdateStatus = nil
+        }
         
         // Try to change to JJY60 while generating (should be blocked)
         coordinator.handleFrequencyChange(to: 4, currentIndex: 0)
-        await Task.yield()
+        await fulfillment(of: [revertExpectation, statusExpectation], timeout: 1.0)
         
         // Verify change was blocked
         let revertSelectionWasCalled = mockPresentationController.revertSelectionWasCalled
@@ -70,9 +81,30 @@ class ModularArchitectureIntegrationTests: XCTestCase {
     }
     
     func testUIStateUpdatesCorrectly() async {
+        let frequencyExpectation = expectation(description: "frequency display callback")
+        let segmentExpectation = expectation(description: "segment selection callback")
+        let buttonExpectation = expectation(description: "button title callback")
+        let timeExpectation = expectation(description: "time display callback")
+        mockPresentationController.onUpdateFrequencyDisplay = { [weak mockPresentationController] in
+            frequencyExpectation.fulfill()
+            mockPresentationController?.onUpdateFrequencyDisplay = nil
+        }
+        mockPresentationController.onUpdateSegmentSelection = { [weak mockPresentationController] in
+            segmentExpectation.fulfill()
+            mockPresentationController?.onUpdateSegmentSelection = nil
+        }
+        mockPresentationController.onUpdateButtonTitle = { [weak mockPresentationController] in
+            buttonExpectation.fulfill()
+            mockPresentationController?.onUpdateButtonTitle = nil
+        }
+        mockPresentationController.onUpdateTimeDisplay = { [weak mockPresentationController] in
+            timeExpectation.fulfill()
+            mockPresentationController?.onUpdateTimeDisplay = nil
+        }
+
         // Refresh UI state
         coordinator.refreshUIState()
-        await Task.yield()
+        await fulfillment(of: [frequencyExpectation, segmentExpectation, buttonExpectation, timeExpectation], timeout: 1.0)
         
         // Verify UI updates were called
         let updateFrequencyDisplayWasCalled = mockPresentationController.updateFrequencyDisplayWasCalled

--- a/Tests/Shared/MockPresentationController.swift
+++ b/Tests/Shared/MockPresentationController.swift
@@ -3,6 +3,7 @@ import Foundation
 
 // MARK: - Shared Mock Presentation Controller
 /// Shared mock implementation for presentation controller to avoid duplication across test files
+@MainActor
 class MockPresentationController: PresentationControllerProtocol {
     // MARK: - Call Tracking Properties
     var updateStatusWasCalled = false

--- a/Tests/Shared/MockPresentationController.swift
+++ b/Tests/Shared/MockPresentationController.swift
@@ -20,36 +20,50 @@ class MockPresentationController: PresentationControllerProtocol {
     var lastSegmentIndex: Int?
     var lastButtonTitle: String?
     var lastTimeDisplay: String?
+
+    // MARK: - Callback Hooks
+    var onUpdateStatus: (() -> Void)?
+    var onRevertSelection: (() -> Void)?
+    var onUpdateFrequencyDisplay: (() -> Void)?
+    var onUpdateSegmentSelection: (() -> Void)?
+    var onUpdateButtonTitle: (() -> Void)?
+    var onUpdateTimeDisplay: (() -> Void)?
     
     // MARK: - PresentationControllerProtocol Implementation
     func updateButtonTitle(_ title: String) {
         updateButtonTitleWasCalled = true
         lastButtonTitle = title
+        onUpdateButtonTitle?()
     }
     
     func updateStatusMessage(_ message: String) {
         updateStatusWasCalled = true
         lastStatusMessage = message
+        onUpdateStatus?()
     }
     
     func updateTimeDisplay(_ timeString: String) {
         updateTimeDisplayWasCalled = true
         lastTimeDisplay = timeString
+        onUpdateTimeDisplay?()
     }
     
     func updateFrequencyDisplay(_ frequencyString: String) {
         updateFrequencyDisplayWasCalled = true
         lastFrequencyDisplay = frequencyString
+        onUpdateFrequencyDisplay?()
     }
     
     func updateSegmentSelection(_ index: Int) {
         updateSegmentSelectionWasCalled = true
         lastSegmentIndex = index
+        onUpdateSegmentSelection?()
     }
     
     func revertSegmentSelection(to index: Int) {
         revertSelectionWasCalled = true
         lastRevertIndex = index
+        onRevertSelection?()
     }
     
     // MARK: - Test Helper Methods
@@ -67,5 +81,12 @@ class MockPresentationController: PresentationControllerProtocol {
         lastSegmentIndex = nil
         lastButtonTitle = nil
         lastTimeDisplay = nil
+
+        onUpdateStatus = nil
+        onRevertSelection = nil
+        onUpdateFrequencyDisplay = nil
+        onUpdateSegmentSelection = nil
+        onUpdateButtonTitle = nil
+        onUpdateTimeDisplay = nil
     }
 }

--- a/Tests/UIStateManagerTests.swift
+++ b/Tests/UIStateManagerTests.swift
@@ -132,9 +132,19 @@ class AudioGeneratorCoordinatorTests: XCTestCase {
     func testHandleFrequencyChangeBlocked() async {
         // Setup mocks
         mockFrequencyManager.validationResult = .blocked("Test error")
+        let revertExpectation = expectation(description: "revert selection callback")
+        let statusExpectation = expectation(description: "status callback")
+        mockPresentationController.onRevertSelection = { [weak mockPresentationController] in
+            revertExpectation.fulfill()
+            mockPresentationController?.onRevertSelection = nil
+        }
+        mockPresentationController.onUpdateStatus = { [weak mockPresentationController] in
+            statusExpectation.fulfill()
+            mockPresentationController?.onUpdateStatus = nil
+        }
         
         coordinator.handleFrequencyChange(to: 3, currentIndex: 0)
-        await Task.yield()
+        await fulfillment(of: [revertExpectation, statusExpectation], timeout: 1.0)
         
         XCTAssertTrue(mockFrequencyManager.validateChangeWasCalled, "Should validate frequency change")
         XCTAssertFalse(mockFrequencyManager.configureFrequencyWasCalled, "Should not configure frequency when blocked")

--- a/Tests/UIStateManagerTests.swift
+++ b/Tests/UIStateManagerTests.swift
@@ -129,12 +129,12 @@ class AudioGeneratorCoordinatorTests: XCTestCase {
         XCTAssertFalse(mockPresentationController.revertSelectionWasCalled, "Should not revert selection when allowed")
     }
     
-    func testHandleFrequencyChangeBlocked() {
+    func testHandleFrequencyChangeBlocked() async {
         // Setup mocks
         mockFrequencyManager.validationResult = .blocked("Test error")
         
         coordinator.handleFrequencyChange(to: 3, currentIndex: 0)
-        RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+        await Task.yield()
         
         XCTAssertTrue(mockFrequencyManager.validateChangeWasCalled, "Should validate frequency change")
         XCTAssertFalse(mockFrequencyManager.configureFrequencyWasCalled, "Should not configure frequency when blocked")

--- a/Tests/UIStateManagerTests.swift
+++ b/Tests/UIStateManagerTests.swift
@@ -134,6 +134,7 @@ class AudioGeneratorCoordinatorTests: XCTestCase {
         mockFrequencyManager.validationResult = .blocked("Test error")
         
         coordinator.handleFrequencyChange(to: 3, currentIndex: 0)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.01))
         
         XCTAssertTrue(mockFrequencyManager.validateChangeWasCalled, "Should validate frequency change")
         XCTAssertFalse(mockFrequencyManager.configureFrequencyWasCalled, "Should not configure frequency when blocked")


### PR DESCRIPTION
## Summary
- mark `PresentationControllerProtocol` as `@MainActor` and remove the temporary `@preconcurrency` conformance from `ViewController`
- update coordinator presentation-update closure signature to `@MainActor` and route updates through a main-actor task
- align affected tests with actor isolation (`@MainActor` test classes / mock + minimal timing waits where UI updates are now asynchronous)

## Validation
- `./scripts/strict_concurrency_check.sh`
- `xcodebuild test -project \"JJYWave.xcodeproj\" -scheme \"JJYWave\" -destination \"platform=macOS\" -only-testing:\"JJYWaveTests/AudioGeneratorCoordinatorTests\" -only-testing:\"JJYWaveTests/ModularArchitectureIntegrationTests\" -only-testing:\"JJYWaveTests/FrequencyPersistenceTests\"`
- `xcodebuild analyze -project \"JJYWave.xcodeproj\" -scheme \"JJYWave\" -destination \"platform=macOS\"`