### PR TITLE
Pilot Swift 6 language mode for app target

### DIFF
--- a/JJYWave.xcodeproj/project.pbxproj
+++ b/JJYWave.xcodeproj/project.pbxproj
@@ -635,7 +635,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -667,7 +667,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
## Summary
- Switch `JJYWave` target build settings from `SWIFT_VERSION = 5.0` to `6.0` (Debug/Release) as a Phase G pilot.
- Keep `JJYWaveTests` on Swift 5 to minimize migration surface and isolate pilot risk.
- Validate pilot with `xcodebuild analyze` and full `xcodebuild test` on macOS.

## Validation
- `xcodebuild -project \"JJYWave.xcodeproj\" -scheme \"JJYWave\" -configuration Debug -destination 'platform=macOS' analyze CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project \"JJYWave.xcodeproj\" -scheme \"JJYWaveTests\" -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`