### PR TITLE
Add Swift 6 analyze/test CI validation

### DIFF
--- a/.github/workflows/swift6-validation.yml
+++ b/.github/workflows/swift6-validation.yml
@@ -29,6 +29,8 @@ jobs:
             -scheme "JJYWave" \
             -configuration Debug \
             -destination "platform=macOS" \
+            SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
+            GCC_TREAT_WARNINGS_AS_ERRORS=YES \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             analyze

--- a/.github/workflows/swift6-validation.yml
+++ b/.github/workflows/swift6-validation.yml
@@ -1,0 +1,57 @@
+name: Swift 6 Validation
+
+on:
+  pull_request:
+    branches:
+      - Gen2
+  push:
+    branches:
+      - Gen2
+
+jobs:
+  analyze:
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Run Xcode Analyze
+        run: |
+          xcodebuild \
+            -project "JJYWave.xcodeproj" \
+            -scheme "JJYWave" \
+            -configuration Debug \
+            -destination "platform=macOS" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            analyze
+
+  tests:
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Run Xcode Tests
+        run: |
+          xcodebuild \
+            test \
+            -project "JJYWave.xcodeproj" \
+            -scheme "JJYWaveTests" \
+            -destination "platform=macOS" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO

--- a/SWIFT6_CONCURRENCY_IMPROVEMENT.md
+++ b/SWIFT6_CONCURRENCY_IMPROVEMENT.md
@@ -147,13 +147,13 @@ Completed:
 2. `swift6-concurrency-phase-b-mainactor-boundary`
 3. `swift6-concurrency-phase-c-strict-diagnostics`
 4. `swift6-concurrency-phase-d-actor-prototype`
-
-Suggested next:
-
 5. `swift6-concurrency-phase-e-strict-gate`
 6. `swift6-concurrency-phase-f-ui-boundary-alignment`
 7. `swift6-concurrency-phase-g-swift6-pilot`
 8. `swift6-concurrency-phase-h-tests-swift6`
+
+Suggested next:
+
 9. `swift6-concurrency-phase-i-ci-hardening`
 
 ## Definition of Done (Updated)

--- a/SWIFT6_CONCURRENCY_IMPROVEMENT.md
+++ b/SWIFT6_CONCURRENCY_IMPROVEMENT.md
@@ -92,7 +92,9 @@ The codebase remains primarily queue-based (`DispatchQueue`, `DispatchSourceTime
 4. Keep validating with strict diagnostics build plus focused and full test suites per phase.
 5. Reassess broader actor migration only after strict checks remain stable with zero timing regressions.
 
-## Recommended Immediate Next Tasks (Phase E)
+## Recommended Immediate Next Tasks (Phase E, Historical)
+
+This section is kept as the original execution plan. Phase E1/E2 and subsequent Swift 6 migration phases are now completed (see status updates below).
 
 ### E1. Strict Concurrency by default (Swift 5 mode)
 

--- a/SWIFT6_CONCURRENCY_IMPROVEMENT.md
+++ b/SWIFT6_CONCURRENCY_IMPROVEMENT.md
@@ -119,6 +119,28 @@ Short answer: **Yes, as diagnostics gate; not yet as full Swift 6 language-mode 
 2. Controlled follow-up: remove current workaround hotspots (especially UI protocol isolation boundary).
 3. Then switch: move to Swift 6 language mode once diagnostics are clean and stable under repeated test runs.
 
+## Phase E/F/G/H Status Update
+
+### Implemented and merged
+
+1. **Phase E1**: strict concurrency diagnostics gate in CI.
+   - `scripts/strict_concurrency_check.sh`
+   - `.github/workflows/strict-concurrency-check.yml`
+2. **Phase E2**: UI boundary actor-isolation alignment.
+   - `PresentationControllerProtocol` moved to `@MainActor` boundary shape.
+   - `ViewController` temporary `@preconcurrency` conformance workaround removed.
+3. **Phase G**: Swift 6 pilot for app target.
+   - `JJYWave` target `SWIFT_VERSION` switched to `6.0`.
+4. **Phase H**: Swift 6 migration for test target.
+   - `JJYWaveTests` target `SWIFT_VERSION` switched to `6.0`.
+   - Test lifecycle setup/teardown paths updated for safe explicit main-actor hops under Swift 6.
+
+### Outcome
+
+- App and test targets are now running in Swift 6 language mode.
+- Strict-concurrency diagnostics gate remains active.
+- Full test and analyze validation has stayed green through staged migration PRs.
+
 ## Suggested Branch/PR Order
 
 Completed:
@@ -133,6 +155,8 @@ Suggested next:
 5. `swift6-concurrency-phase-e-strict-gate`
 6. `swift6-concurrency-phase-f-ui-boundary-alignment`
 7. `swift6-concurrency-phase-g-swift6-pilot`
+8. `swift6-concurrency-phase-h-tests-swift6`
+9. `swift6-concurrency-phase-i-ci-hardening`
 
 ## Definition of Done (Updated)
 
@@ -142,3 +166,15 @@ Suggested next:
 4. Actor migration decisions are based on measured prototype results, not assumptions.
 5. Strict-concurrency diagnostics are continuously enforced in CI.
 6. Swift 6 language mode migration is completed only after hotspot cleanup and stable repeated test runs.
+
+## Recommended Immediate Next Tasks (Phase I)
+
+### I1. Swift 6 steady-state CI validation
+
+1. Add dedicated CI workflow running `xcodebuild analyze` on `JJYWave` and `xcodebuild test` on `JJYWaveTests` for PRs and pushes to `Gen2`.
+2. Keep existing strict-concurrency diagnostics gate in parallel as regression guard.
+
+### I2. Baseline maintenance
+
+1. Keep migration-related fixes minimal and scoped to concurrency correctness.
+2. Treat new Swift 6 isolation warnings in touched files as merge blockers.

--- a/SWIFT6_CONCURRENCY_IMPROVEMENT.md
+++ b/SWIFT6_CONCURRENCY_IMPROVEMENT.md
@@ -175,4 +175,4 @@ Suggested next:
 ### I2. Baseline maintenance
 
 1. Keep migration-related fixes minimal and scoped to concurrency correctness.
-2. Treat new Swift 6 isolation warnings in touched files as merge blockers.
+2. Treat new Swift 6 isolation warnings surfaced by the strict-concurrency gate and the warning-as-error Analyze path as merge blockers; track test-target warning debt cleanup separately before enabling warnings-as-errors for the full test job.

--- a/SWIFT6_CONCURRENCY_IMPROVEMENT.md
+++ b/SWIFT6_CONCURRENCY_IMPROVEMENT.md
@@ -111,13 +111,11 @@ The codebase remains primarily queue-based (`DispatchQueue`, `DispatchSourceTime
 1. After E1/E2 are green, pilot `SWIFT_VERSION = 6.0` on the smallest safe target surface first.
 2. Promote to repository-wide Swift 6 language mode only after pilot completes without timing regressions or flaky tests.
 
-## Should We Enable Strict Concurrency Now?
+## Should We Enable Strict Concurrency Now? (Historical)
 
-Short answer: **Yes, as diagnostics gate; not yet as full Swift 6 language-mode switch across the whole repository.**
+Original recommendation (at the time): **Yes, as diagnostics gate; not yet as full Swift 6 language-mode switch across the whole repository.**
 
-1. Immediate go: strict-concurrency diagnostics should be continuously enforced.
-2. Controlled follow-up: remove current workaround hotspots (especially UI protocol isolation boundary).
-3. Then switch: move to Swift 6 language mode once diagnostics are clean and stable under repeated test runs.
+Current status: app and test targets have now been migrated to Swift 6 language mode (see Phase E/F/G/H status below), and strict-concurrency diagnostics remain continuously enforced in CI.
 
 ## Phase E/F/G/H Status Update
 


### PR DESCRIPTION
## Summary
- Add a dedicated CI workflow that runs `xcodebuild analyze` for `JJYWave` and `xcodebuild test` for `JJYWaveTests` on PRs/pushes to `Gen2`.
- Keep existing strict-concurrency diagnostics gate unchanged; this PR adds steady-state Swift 6 validation coverage in parallel.
- Update Swift concurrency roadmap doc with completed Phase E/F/G/H status and Phase I next-step tracking.

## Validation
- `xcodebuild -project \"JJYWave.xcodeproj\" -scheme \"JJYWave\" -configuration Debug -destination 'platform=macOS' analyze CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project \"JJYWave.xcodeproj\" -scheme \"JJYWaveTests\" -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`