### PR TITLE
Use Node24-compatible actions in Swift 6 validation

### DIFF
--- a/.github/workflows/swift6-validation.yml
+++ b/.github/workflows/swift6-validation.yml
@@ -36,10 +36,15 @@ jobs:
               try:
                   with open(info_plist, 'rb') as fp:
                       version = plistlib.load(fp).get('CFBundleShortVersionString', '')
-              except Exception:
-                  version = ''
+              except Exception as exc:
+                  raise SystemExit(f'Failed to read Xcode version from {info_plist}: {exc}')
+
               parts = [int(p) for p in re.findall(r'\d+', str(version))]
-              return tuple(parts) if parts else (0,)
+              if not parts:
+                  raise SystemExit(
+                      f'Failed to parse CFBundleShortVersionString for {app_path}: {version!r}'
+                  )
+              return tuple(parts)
 
           stable = [
               p for p in candidates

--- a/.github/workflows/swift6-validation.yml
+++ b/.github/workflows/swift6-validation.yml
@@ -14,10 +14,12 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Checkout
+      - &checkout_step
+        name: Checkout
         uses: actions/checkout@v6
 
-      - name: Select Latest Installed Xcode
+      - &select_xcode_step
+        name: Select Latest Installed Xcode
         run: |
           python3 - <<'PY'
           import glob
@@ -52,7 +54,8 @@ jobs:
               env_file.write(f"DEVELOPER_DIR={selected}/Contents/Developer\n")
           PY
 
-      - name: Show Xcode Version
+      - &show_xcode_step
+        name: Show Xcode Version
         run: xcodebuild -version
 
       - name: Run Xcode Analyze
@@ -73,46 +76,9 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Select Latest Installed Xcode
-        run: |
-          python3 - <<'PY'
-          import glob
-          import os
-          import plistlib
-          import re
-
-          candidates = glob.glob('/Applications/Xcode*.app')
-          if not candidates:
-              raise SystemExit('No Xcode installation found under /Applications')
-
-          def parse_version(app_path: str):
-              info_plist = os.path.join(app_path, 'Contents', 'Info.plist')
-              try:
-                  with open(info_plist, 'rb') as fp:
-                      version = plistlib.load(fp).get('CFBundleShortVersionString', '')
-              except Exception:
-                  version = ''
-              parts = [int(p) for p in re.findall(r'\d+', str(version))]
-              return tuple(parts) if parts else (0,)
-
-          stable = [
-              p for p in candidates
-              if 'beta' not in os.path.basename(p).lower()
-              and 'rc' not in os.path.basename(p).lower()
-          ]
-          pool = stable or candidates
-          selected = max(pool, key=parse_version)
-
-          print(f"Selected Xcode app: {selected}")
-          with open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8') as env_file:
-              env_file.write(f"DEVELOPER_DIR={selected}/Contents/Developer\n")
-          PY
-
-      - name: Show Xcode Version
-        run: xcodebuild -version
+      - *checkout_step
+      - *select_xcode_step
+      - *show_xcode_step
 
       - name: Run Xcode Tests
         run: |

--- a/.github/workflows/swift6-validation.yml
+++ b/.github/workflows/swift6-validation.yml
@@ -15,12 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
+      - name: Show Xcode Version
+        run: xcodebuild -version
 
       - name: Run Xcode Analyze
         run: |
@@ -41,12 +39,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Select Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
+      - name: Show Xcode Version
+        run: xcodebuild -version
 
       - name: Run Xcode Tests
         run: |

--- a/.github/workflows/swift6-validation.yml
+++ b/.github/workflows/swift6-validation.yml
@@ -29,27 +29,23 @@ jobs:
           if not candidates:
               raise SystemExit('No Xcode installation found under /Applications')
 
-          preferred = '/Applications/Xcode.app'
-          if preferred in candidates:
-              selected = preferred
-          else:
-              def parse_version(app_path: str):
-                  info_plist = os.path.join(app_path, 'Contents', 'Info.plist')
-                  try:
-                      with open(info_plist, 'rb') as fp:
-                          version = plistlib.load(fp).get('CFBundleShortVersionString', '')
-                  except Exception:
-                      version = ''
-                  parts = [int(p) for p in re.findall(r'\d+', str(version))]
-                  return tuple(parts) if parts else (0,)
+          def parse_version(app_path: str):
+              info_plist = os.path.join(app_path, 'Contents', 'Info.plist')
+              try:
+                  with open(info_plist, 'rb') as fp:
+                      version = plistlib.load(fp).get('CFBundleShortVersionString', '')
+              except Exception:
+                  version = ''
+              parts = [int(p) for p in re.findall(r'\d+', str(version))]
+              return tuple(parts) if parts else (0,)
 
-              stable = [
-                  p for p in candidates
-                  if 'beta' not in os.path.basename(p).lower()
-                  and 'rc' not in os.path.basename(p).lower()
-              ]
-              pool = stable or candidates
-              selected = max(pool, key=parse_version)
+          stable = [
+              p for p in candidates
+              if 'beta' not in os.path.basename(p).lower()
+              and 'rc' not in os.path.basename(p).lower()
+          ]
+          pool = stable or candidates
+          selected = max(pool, key=parse_version)
 
           print(f"Selected Xcode app: {selected}")
           with open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8') as env_file:
@@ -92,27 +88,23 @@ jobs:
           if not candidates:
               raise SystemExit('No Xcode installation found under /Applications')
 
-          preferred = '/Applications/Xcode.app'
-          if preferred in candidates:
-              selected = preferred
-          else:
-              def parse_version(app_path: str):
-                  info_plist = os.path.join(app_path, 'Contents', 'Info.plist')
-                  try:
-                      with open(info_plist, 'rb') as fp:
-                          version = plistlib.load(fp).get('CFBundleShortVersionString', '')
-                  except Exception:
-                      version = ''
-                  parts = [int(p) for p in re.findall(r'\d+', str(version))]
-                  return tuple(parts) if parts else (0,)
+          def parse_version(app_path: str):
+              info_plist = os.path.join(app_path, 'Contents', 'Info.plist')
+              try:
+                  with open(info_plist, 'rb') as fp:
+                      version = plistlib.load(fp).get('CFBundleShortVersionString', '')
+              except Exception:
+                  version = ''
+              parts = [int(p) for p in re.findall(r'\d+', str(version))]
+              return tuple(parts) if parts else (0,)
 
-              stable = [
-                  p for p in candidates
-                  if 'beta' not in os.path.basename(p).lower()
-                  and 'rc' not in os.path.basename(p).lower()
-              ]
-              pool = stable or candidates
-              selected = max(pool, key=parse_version)
+          stable = [
+              p for p in candidates
+              if 'beta' not in os.path.basename(p).lower()
+              and 'rc' not in os.path.basename(p).lower()
+          ]
+          pool = stable or candidates
+          selected = max(pool, key=parse_version)
 
           print(f"Selected Xcode app: {selected}")
           with open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8') as env_file:

--- a/.github/workflows/swift6-validation.yml
+++ b/.github/workflows/swift6-validation.yml
@@ -17,6 +17,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Select Latest Installed Xcode
+        run: |
+          python3 - <<'PY'
+          import glob
+          import os
+
+          candidates = sorted(glob.glob('/Applications/Xcode*.app'))
+          if not candidates:
+              raise SystemExit('No Xcode installation found under /Applications')
+
+          selected = candidates[-1]
+          print(f"Selected Xcode app: {selected}")
+          with open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8') as env_file:
+              env_file.write(f"DEVELOPER_DIR={selected}/Contents/Developer\n")
+          PY
+
       - name: Show Xcode Version
         run: xcodebuild -version
 
@@ -40,6 +56,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Select Latest Installed Xcode
+        run: |
+          python3 - <<'PY'
+          import glob
+          import os
+
+          candidates = sorted(glob.glob('/Applications/Xcode*.app'))
+          if not candidates:
+              raise SystemExit('No Xcode installation found under /Applications')
+
+          selected = candidates[-1]
+          print(f"Selected Xcode app: {selected}")
+          with open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8') as env_file:
+              env_file.write(f"DEVELOPER_DIR={selected}/Contents/Developer\n")
+          PY
 
       - name: Show Xcode Version
         run: xcodebuild -version

--- a/.github/workflows/swift6-validation.yml
+++ b/.github/workflows/swift6-validation.yml
@@ -22,12 +22,35 @@ jobs:
           python3 - <<'PY'
           import glob
           import os
+          import plistlib
+          import re
 
-          candidates = sorted(glob.glob('/Applications/Xcode*.app'))
+          candidates = glob.glob('/Applications/Xcode*.app')
           if not candidates:
               raise SystemExit('No Xcode installation found under /Applications')
 
-          selected = candidates[-1]
+          preferred = '/Applications/Xcode.app'
+          if preferred in candidates:
+              selected = preferred
+          else:
+              def parse_version(app_path: str):
+                  info_plist = os.path.join(app_path, 'Contents', 'Info.plist')
+                  try:
+                      with open(info_plist, 'rb') as fp:
+                          version = plistlib.load(fp).get('CFBundleShortVersionString', '')
+                  except Exception:
+                      version = ''
+                  parts = [int(p) for p in re.findall(r'\d+', str(version))]
+                  return tuple(parts) if parts else (0,)
+
+              stable = [
+                  p for p in candidates
+                  if 'beta' not in os.path.basename(p).lower()
+                  and 'rc' not in os.path.basename(p).lower()
+              ]
+              pool = stable or candidates
+              selected = max(pool, key=parse_version)
+
           print(f"Selected Xcode app: {selected}")
           with open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8') as env_file:
               env_file.write(f"DEVELOPER_DIR={selected}/Contents/Developer\n")
@@ -62,12 +85,35 @@ jobs:
           python3 - <<'PY'
           import glob
           import os
+          import plistlib
+          import re
 
-          candidates = sorted(glob.glob('/Applications/Xcode*.app'))
+          candidates = glob.glob('/Applications/Xcode*.app')
           if not candidates:
               raise SystemExit('No Xcode installation found under /Applications')
 
-          selected = candidates[-1]
+          preferred = '/Applications/Xcode.app'
+          if preferred in candidates:
+              selected = preferred
+          else:
+              def parse_version(app_path: str):
+                  info_plist = os.path.join(app_path, 'Contents', 'Info.plist')
+                  try:
+                      with open(info_plist, 'rb') as fp:
+                          version = plistlib.load(fp).get('CFBundleShortVersionString', '')
+                  except Exception:
+                      version = ''
+                  parts = [int(p) for p in re.findall(r'\d+', str(version))]
+                  return tuple(parts) if parts else (0,)
+
+              stable = [
+                  p for p in candidates
+                  if 'beta' not in os.path.basename(p).lower()
+                  and 'rc' not in os.path.basename(p).lower()
+              ]
+              pool = stable or candidates
+              selected = max(pool, key=parse_version)
+
           print(f"Selected Xcode app: {selected}")
           with open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8') as env_file:
               env_file.write(f"DEVELOPER_DIR={selected}/Contents/Developer\n")


### PR DESCRIPTION
## Summary
- Update actions/checkout from @v4 to @v6 in swift6-validation.yml.
- Remove maxim-lobanov/setup-xcode@v1 (Node20 runtime).
- Select the highest stable installed Xcode deterministically by parsing CFBundleShortVersionString and exporting DEVELOPER_DIR.
- Reuse checkout/Xcode setup/version-reporting steps via YAML anchors to avoid drift between analyze/tests jobs.
- Add fail-fast error handling when Xcode Info.plist version metadata cannot be read or parsed.

## Validation
- xcodebuild analyze -project "JJYWave.xcodeproj" -scheme "JJYWave" -destination "platform=macOS" -configuration Debug CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO SWIFT_TREAT_WARNINGS_AS_ERRORS=YES GCC_TREAT_WARNINGS_AS_ERRORS=YES
- xcodebuild test -project "JJYWave.xcodeproj" -scheme "JJYWaveTests" -destination "platform=macOS" -configuration Debug CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
- Swift 6 Validation workflow run: 23099245853 (analyze passed, tests passed)